### PR TITLE
feat: improve KDL syntax highlighting and support comments

### DIFF
--- a/kdl.lua
+++ b/kdl.lua
@@ -4,3 +4,10 @@ local config = import("micro/config")
 
 config.RegisterCommonOption("kdl", "kdl", true)
 config.AddRuntimeFile("kdl", config.RTSyntax, "kdl.yaml")
+
+-- Set the comment character format when a KDL buffer is opened
+function onBufferOpen(buf)
+    if buf.Settings["filetype"] == "kdl" then
+        buf.Settings["comment.type"] = "// %s"
+    end
+end

--- a/kdl.yaml
+++ b/kdl.yaml
@@ -13,8 +13,8 @@ rules:
       end: '"'
       skip: '(\\\\\|\\")'
       rules:
-        - constant.specialChar: '\\u[[:xdigit:]]{1,6}'
-        - constant.specialChar: '\\[btnfr"\\]'
+        - constant.specialChar: '\\u\{[[:xdigit:]]{1,6}\}'
+        - constant.specialChar: '\\[btnfr"\\/]'
   # Raw Strings
   # These definitions are not correct, ideally `#` should be same count for both begin and end, but it should be programmable as captured \1
   # In my understanding, this is a micro editor restriction. See https://github.com/zyedidia/micro/blob/21bb61c5ff3cd4cd11adbd521657df90d50f54c7/runtime/syntax/jsonnet.yaml#L61-L78
@@ -35,30 +35,40 @@ rules:
       start: '\br###"'
       end: '"###'
       rules: []
-  # Integer
-  - constant.number: '[-+]?(\d+)'
-  # Float
-  - constant.number: '[-+]?(\d+)\.\d*'
-  # Boolean and inf, nan without sign
+  # Type annotations
+  - type: '\([^)]+\)'
+  # Numbers
+  # Hexadecimal
+  - constant.number: '[+-]?\b0x[[:xdigit:]_]+\b'
+  # Octal
+  - constant.number: '[+-]?\b0o[0-7_]+\b'
+  # Binary
+  - constant.number: '[+-]?\b0b[01_]+\b'
+  # Decimal and Float (including scientific notation and underscores)
+  - constant.number: '[+-]?\b[0-9_]+(\.[0-9_]+)?([eE][+-]?[0-9_]+)?\b'
+  # Boolean and Null
   - constant.bool.true: '\btrue\b'
   - constant.bool.false: '\bfalse\b'
+  - constant: '\bnull\b'
   # Comments
   - comment:
       start: '//'
       end: '$'
       rules:
         - todo: '(TODO|FIXME|XXX|NOTE)'
+  # Block Comments
+  - comment:
+      start: '/\*'
+      end: '\*/'
+      rules:
+        - todo: '(TODO|FIXME|XXX|NOTE)'
   # Slashdash comments
-  # https://github.com/kdl-org/kdl/blob/de1dbd2c330c9193b836499db241787484627c3b/SPEC.md#L77-L79
-  # vscode extension realizes this with lookahead and lookbehind, the regex feature cannot be used in micro
-  # https://github.com/kdl-org/vscode-kdl/blob/646d7b819d72b2f0d9dd05102a305506bafa3cf6/syntaxes/kdl.tmLanguage.json#L182-L199
-  # https://github.com/zyedidia/micro/issues/901#issuecomment-354931928
-  # So simplified it, it means this is inaccurate
-  - comment.block:
-      start: '^\s*/-'
-      end: '\s'
+  # Highlights the /- prefix and the immediately following commented-out element
+  - comment:
+      start: '/-\s*[^{\n]*\{'
+      end: '\}'
       rules: []
-  - comment.block:
-      start: '/-{'
-      end: '}'
-      rules: []
+  - comment: '/-\s*\([^)]+\)'  # Commented-out type annotation
+  - comment: '/-\s*"([^"\\]|\\.)*"'  # Commented-out quoted string
+  - comment: '/-\s*r(###"[^"]*"###|##"[^"]*"##|#"[^"]*"#|"[^"]*")'  # Commented-out raw strings
+  - comment: '/-\s*[a-zA-Z0-9_\-\.\/=]+'  # Commented-out identifier, property, number or keyword


### PR DESCRIPTION
This PR brings several improvements to KDL support in micro:

- **Comments Support**: Added an `onBufferOpen` hook in `kdl.lua` to register the comment format `// %s` for KDL files.
- **Block & Slashdash comments**: Added support for block comments (`/* ... */`) and improved slashdash comments (`/-`) highlighting rules.
- **Numbers**: Extended number highlighting to support:
  - Hexadecimal (`0x...`)
  - Octal (`0o...`)
  - Binary (`0b...`)
  - Decimal and Float (supporting scientific notation and underscores like `1_000.05`).
- **Other improvements**: Added type annotations `(...)` highlighting and support for `null` literal.
